### PR TITLE
Fix README title to match directory name

### DIFF
--- a/examples/datachannel/README.md
+++ b/examples/datachannel/README.md
@@ -1,4 +1,4 @@
-# basic
+# datachannel
 datachannel demonstrates how handoff can move a RTCPeerConnection
 to a backend Go process. If you press `start` both PeerConnections will
 run in the browser. If you check `Override` handoff is enabled and will


### PR DESCRIPTION
## Summary

This PR fixes the README title in `examples/datachannel/README.md` from `# basic` to `# datachannel` to match the directory name and be consistent with other example READMEs.

## Changes

- Changed the first line from `# basic` to `# datachannel`

This is a minor documentation fix to improve consistency across the examples directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)